### PR TITLE
Updated initialization of ImageFactory to new webtrees 2.2.3 API

### DIFF
--- a/WatermarkModule.php
+++ b/WatermarkModule.php
@@ -13,6 +13,7 @@ require __DIR__ . '/MyImageFactory.php';
 
 use Fisharebest\Localization\Translation;
 use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Services\PhpService;
 use Fisharebest\Webtrees\View;
 use Fisharebest\Webtrees\Module\AbstractModule;
 use Fisharebest\Webtrees\Module\ModuleCustomInterface;
@@ -83,7 +84,7 @@ class WatermarkModule extends AbstractModule implements ModuleCustomInterface
      */
     public function boot(): void
     {
-        Registry::ImageFactory(new MyImageFactory());
+        Registry::ImageFactory(new MyImageFactory(new PhpService));
         
         
     }


### PR DESCRIPTION
Hi photon-flip,

just recognized that your custom module is not running with the latest webtrees 2.2/2.2.3 API. 

With the attached pull request, I could avoid the PHP errors in my 2.2.3 installation. The module seems to run without error now.

However, I could not check if the functionality of the watermark-module is also working, because I lack the background about this functionality.